### PR TITLE
fix(ssr): properly export request handler

### DIFF
--- a/server-fastify.ts
+++ b/server-fastify.ts
@@ -1,13 +1,13 @@
 import {
   AngularNodeAppEngine,
-  writeResponseToNodeResponse,
-  isMainModule,
   createNodeRequestHandler,
+  isMainModule,
+  writeResponseToNodeResponse,
 } from '@angular/ssr/node';
-import fastify from 'fastify';
 import fastifyStatic from '@fastify/static';
-import { fileURLToPath } from 'node:url';
+import fastify from 'fastify';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export function app() {
   const server = fastify();
@@ -48,7 +48,7 @@ if (isMainModule(import.meta.url)) {
 
 console.warn('Fastify server started');
 
-export default createNodeRequestHandler(async (req, res) => {
+export const reqHandler = createNodeRequestHandler(async (req, res) => {
   await server.ready();
   server.server.emit('request', req, res);
 });

--- a/server-h3.ts
+++ b/server-h3.ts
@@ -2,8 +2,8 @@ import { AngularAppEngine, createRequestHandler } from '@angular/ssr';
 import {
   createApp,
   createRouter,
-  toWebHandler,
   defineEventHandler,
+  toWebHandler,
   toWebRequest,
 } from 'h3';
 
@@ -28,4 +28,4 @@ export function app() {
 
 const server = app();
 const handler = toWebHandler(server);
-export default createRequestHandler(handler);
+export const reqHandler = createRequestHandler(handler);

--- a/server-hono.ts
+++ b/server-hono.ts
@@ -1,6 +1,5 @@
 import { AngularAppEngine, createRequestHandler } from '@angular/ssr';
 import { Hono } from 'hono';
-import { getConnInfo } from 'hono/cloudflare-workers';
 
 export function app() {
   const server = new Hono();
@@ -17,4 +16,4 @@ export function app() {
 }
 
 const server = app();
-export default createRequestHandler(server.fetch);
+export const reqHandler = createRequestHandler(server.fetch);

--- a/server.ts
+++ b/server.ts
@@ -1,12 +1,12 @@
 import {
   AngularNodeAppEngine,
-  writeResponseToNodeResponse,
-  isMainModule,
   createNodeRequestHandler,
+  isMainModule,
+  writeResponseToNodeResponse,
 } from '@angular/ssr/node';
 import express from 'express';
-import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export function app(): express.Express {
   const server = express();
@@ -57,4 +57,4 @@ if (isMainModule(import.meta.url)) {
 console.warn('Node Express server started');
 
 // This exposes the RequestHandler
-export default createNodeRequestHandler(server);
+export const reqHandler = createNodeRequestHandler(server);


### PR DESCRIPTION
We need to explicitly export `reqHandler` since https://github.com/angular/angular-cli/pull/28614.